### PR TITLE
Explicitly allow write access to GITHUB_TOKEN for issues (PR comments)

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,12 +1,12 @@
 name: Check
 on: [pull_request]
+permissions:
+  issues: write
 jobs:
 
   check:
     name: Check rewrite function
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
 
       - uses: actions/checkout@v2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,7 +1,7 @@
 name: Check
 on: [pull_request]
-permissions:
-  issues: write
+#permissions:
+#  issues: write
 jobs:
 
   check:
@@ -22,21 +22,24 @@ jobs:
         if: success() || failure()
         run: cat test-results.tap | ./.ci/tapview | tee test-results.txt
 
-      - name: Collect tapview output
-        if: (success() || failure()) && github.event_name == 'pull_request'
-        run: |
-          echo 'TEST_RESULTS<<EOF' >> $GITHUB_ENV
-          cat test-results.txt >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+      # GITHUB_TOKEN is restricted on the org account and yet all of the settings should allow it to comment:
+      #   https://github.com/galaxyproject/gxy.io/pull/3
 
-      - uses: actions/github-script@v1
-        if: (success() || failure()) && github.event_name == 'pull_request'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `${{ env.TEST_RESULTS }}`
-            })
+      #- name: Collect tapview output
+      #  if: (success() || failure()) && github.event_name == 'pull_request'
+      #  run: |
+      #    echo 'TEST_RESULTS<<EOF' >> $GITHUB_ENV
+      #    cat test-results.txt >> $GITHUB_ENV
+      #    echo 'EOF' >> $GITHUB_ENV
+
+      #- uses: actions/github-script@v1
+      #  if: (success() || failure()) && github.event_name == 'pull_request'
+      #  with:
+      #    github-token: ${{ secrets.GITHUB_TOKEN }}
+      #    script: |
+      #      github.issues.createComment({
+      #        issue_number: context.issue.number,
+      #        owner: context.repo.owner,
+      #        repo: context.repo.repo,
+      #        body: `${{ env.TEST_RESULTS }}`
+      #      })

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,6 +5,8 @@ jobs:
   check:
     name: Check rewrite function
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hopefully this works, I can't really test it. These permissions are causing the check failure with #2. I have been all over the org and repo settings and cannot find anywhere that restricts the token permissions, but it's clearly different on my fork:

```
GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Packages: write
  Pages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write
```

vs. the org repo:

```
GITHUB_TOKEN Permissions
  Actions: read
  Checks: read
  Contents: read
  Deployments: read
  Discussions: read
  Issues: read
  Metadata: read
  Packages: read
  Pages: read
  PullRequests: read
  RepositoryProjects: read
  SecurityEvents: read
  Statuses: read
```