### PR TITLE
update GTN Slack link

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -82,7 +82,7 @@ gxy_io_rewrites:
 
   # GTN Slack Space
   - src: /(gtn|smorg|smorgasbord)-?slack
-    dest: https://join.slack.com/t/gtnsmrgsbord/shared_invite/zt-1v7hmh9hg-MvudHCrEKdF7VTRVj8dOJg
+    dest: https://join.slack.com/t/gtnsmrgsbord/shared_invite/zt-1vl98zkuu-_gZw9RdEjPjHIs6fnBUHfw
     tests:
       - /gtnslack
       - /gtn-slack


### PR DESCRIPTION
because it expired for some reason, maybe because of the 400 ppl max per invite?