### PR TITLE
update deployment CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5 
+      
       - name: Install boto3
         run: pip install boto3
 


### PR DESCRIPTION
I think https://github.com/galaxyproject/gxy.io/pull/44 failed. This PR tries to setup a Python venv instead of using the system Python. We could also just roll back to the previous Ubuntu release.