### PR TITLE
Update GitHub Actions to use latest versions of checkout, setup-python, and upload-artifact

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -24,7 +24,7 @@ jobs:
           cat test-results.tap | ./.ci/tapview | tee test-results/test-results.txt
 
       - name: Upload tapview results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results/


### PR DESCRIPTION
Just got an email about github retiring upload-artifact soon, so here's an update.