### PR TITLE
Use ubuntu-22.04 instead of latest for deploy action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   deploy:
     name: Deploy rewrite function
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
       - uses: actions/checkout@v4

--- a/lambda.yaml
+++ b/lambda.yaml
@@ -37,7 +37,6 @@
             role: "{{ gxy_io_lambda_exec_role_arn }}"
             handler: "lambda_function.lambda_handler"
             region: "us-east-1"
-          no_log: true
           register: __gxy_io_lambda_deploy
 
         - name: Set new ARN fact


### PR DESCRIPTION
This should get us the older ansible back, giving more time to deal with the deprecation warning related to zipfile non-utf8 contents breaking the deploy action.