### PR TITLE
update GTN invite link

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -156,7 +156,7 @@ gxy_io_rewrites:
 
   # GTN Slack Space
   - src: /(gtn|smorg|smorgasbord)-?slack
-    dest: https://join.slack.com/t/gtnsmrgsbord/shared_invite/zt-2s11w2hdf-LDf4HD5OqPHQYhc2w0lrXg
+    dest: https://join.slack.com/t/gtnsmrgsbord/shared_invite/zt-32v6bk5jk-l~t6acwPfjshjeSQGdKrfw
     tests:
       - /gtnslack
       - /gtn-slack


### PR DESCRIPTION
The invite link to the GTN Slack had expired, adding a fresh one

@teresa-m whenever it expires next, you can get a new invite link inside GTN Slack, then add it here (in case it happens and I am unavailable)