### PR TITLE
Version tpv database

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -208,6 +208,15 @@ gxy_io_rewrites:
 
   # TPV shared database
   - src: /tpv/db.yml
+    dest: https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/9ec8ff26012db320bbaeac9b678499000d2af421/tools.yml
+
+  - src: /tpv/db-v1.yml
+    dest: https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/9ec8ff26012db320bbaeac9b678499000d2af421/tools.yml
+
+  - src: /tpv/db-v2.yml
+    dest: https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/main/tools.yml
+
+  - src: /tpv/db-latest.yml
     dest: https://raw.githubusercontent.com/galaxyproject/tpv-shared-database/main/tools.yml
 
   # UseGalaxy.org colabfold request form


### PR DESCRIPTION
db-latest will point to latest.
db.yml now points to v1 as does db-v1.yml
db-v2.yml also currently points to latest.

This will allow us more flexibility when introducing breaking changes, such as: https://github.com/galaxyproject/tpv-shared-database/pull/85 and https://github.com/galaxyproject/tpv-shared-database/pull/86

I'm thinking we do major versions only, avoiding minor versions. One can always point to specific commits if an exact version is needed.