### PR TITLE
Add /brc-e2e-rna to all.yaml

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -37,6 +37,8 @@ gxy_io_rewrites:
     dest: https://docs.google.com/presentation/d/1gEEsNWAhKqZXrvUDN63Gj9WWlwnjJ0AQkZvyIZFdOsM
   - src: /cordi-2025
     dest: https://docs.google.com/presentation/d/1jrUaEW44bUgMjLlA94KvMmrnwiJholoGEuUtBy3IpXk
+  - src: /brc-e2e-rna
+    dest: https://docs.google.com/presentation/d/1sxwuWPvfESbBedYtuW1FKAZ93J4jWw13KAdpd3X4sOw/edit?usp=sharing
 
   # Promo sites
   - src: /what-is-galaxy


### PR DESCRIPTION
## Summary
- Add shortened URL for BRC end-to-end RNA presentation: `gxy.io/brc-e2e-rna`