### PR TITLE
Add /asv26 short link for ASV 2026 slides

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -39,6 +39,9 @@ gxy_io_rewrites:
     dest: https://docs.google.com/presentation/d/1jrUaEW44bUgMjLlA94KvMmrnwiJholoGEuUtBy3IpXk
   - src: /brc-e2e-rna
     dest: https://docs.google.com/presentation/d/1sxwuWPvfESbBedYtuW1FKAZ93J4jWw13KAdpd3X4sOw/edit?usp=sharing
+    # American Society for Virology 2026
+  - src: /asv26
+    dest: https://nekrut.github.io/slides/asv2026/
 
   # Promo sites
   - src: /what-is-galaxy


### PR DESCRIPTION
Adds a short link for my American Society for Virology 2026 talk.

```yaml
- src: /asv26
  dest: https://nekrut.github.io/slides/asv2026/
```

The destination is live and returns 200. Placed at the end of the "Conferences and meetings" block, alongside the other talk links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)