### PR TITLE
Fix PR check workflow blocked by fork checkout guard

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,6 @@
 name: Check
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -13,27 +13,33 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
 
       - name: Checkout PR code
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run check
         run: ansible-playbook -i hosts check.yaml
 
-      - name: Post comment to PR
+      - name: Publish test results
         if: success() || failure()
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const { execSync } = require('child_process');
-            const body = execSync('cat test-results.tap | ./.ci/tapview', { encoding: 'utf8' });
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body
-            });
+        run: |
+          {
+            echo '## Rewrite function test results'
+            echo
+            if [ -f test-results.tap ]; then
+              echo '```'
+              ./.ci/tapview < test-results.tap || true
+              echo '```'
+              echo
+              echo '<details><summary>Raw TAP output</summary>'
+              echo
+              echo '```'
+              cat test-results.tap
+              echo '```'
+              echo
+              echo '</details>'
+            else
+              echo 'No test results were produced: the check failed before the tests ran, see the job log.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The `Check` workflow has been failing on fork PRs (e.g. #131) before it runs a single test:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

`actions/checkout@v5` now blocks checking out fork code from a `pull_request_target` workflow by default, because that combination runs untrusted code with the base repo's write token — the classic "pwn request" shape. The follow-on errors (`./.ci/tapview: not found`, `test-results.tap: No such file`) are just the comment step tripping over a workspace that was never checked out.

Rather than opting back in with `allow-unsafe-pr-checkout: true`, this removes the need for the trusted context entirely.

## Change

- Trigger on `pull_request` instead of `pull_request_target`, and check out the default merge ref. Fork PRs now get a read-only token by construction, so there is nothing for the guard to refuse and no write token exposed to PR-authored playbooks, templates, or test code.
- Narrow `permissions` to `contents: read` — `pull-requests: write` existed only to post the results comment.
- Replace the comment step with one that appends the `tapview` summary, plus the raw TAP in a collapsed block, to `$GITHUB_STEP_SUMMARY`. It handles a missing `test-results.tap` explicitly, so an infra failure reports the real cause instead of an unhandled `execSync` error.

The tradeoff: results move from a PR comment to the check's summary tab. Pass/fail is still visible on the PR via the check status. If the comment turns out to be worth keeping for drive-by contributors, it can be restored later by uploading the TAP as an artifact and posting it from a separate job that never checks out PR code — without touching the test side.

## Verification

Locally, `ansible-playbook -i hosts check.yaml` passes and writes `test-results.tap` to the repo root, where the summary step looks for it. The summary step's `run` body was extracted from the YAML and executed under `bash -e` in three states:

- passing TAP → `148 tests, 0 failures.`
- failing TAP → renders the `not ok` lines and `2 tests, 1 failures.`
- missing file → fallback message

All three exit 0, so the summary always renders in full; job pass/fail comes from the `Run check` step.